### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,4 +1,6 @@
 name: Jekyll site CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MohamedAbdo157/Lozaria-store/security/code-scanning/1](https://github.com/MohamedAbdo157/Lozaria-store/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, since the workflow only checks out code and builds the site (with no write operations to the repository or other resources), the minimal permission required is `contents: read`. This block should be added at the top level of the workflow file, just after the `name` field and before the `on` field, to apply to all jobs in the workflow. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
